### PR TITLE
Dockerの外部ネットワークを使用するように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+.DS_Store
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# mac os metafile
 .DS_Store
+
+#vscode settings
 .vscode

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ Currently, go build is required for each submodules.
     cd ../gateway/simple
     go build
 
-## Run with docker
+### Run with docker
 ``` shell
+# create network
+docker network create synerex_net
+
 # build image
 docker-compose build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - "nodeserv"
     volumes:
       - ./server:/go/src/github.com/synerex_server
-      - ./server/entrypoint.sh
     ports:
       - "10000:10000"
     networks: 
@@ -28,7 +27,6 @@ services:
     image: synerex_nodeserv
     volumes:
       - ./nodeserv:/go/src/github.com/synerex_nodeserv
-      - ./nodeserv/entrypoint.sh
     ports:
       - "9990:9990"
     networks: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,12 @@ services:
       - "nodeserv"
     volumes:
       - ./server:/go/src/github.com/synerex_server
+      - ./server/entrypoint.sh
     ports:
       - "10000:10000"
     networks: 
       - synerex_net
+      - default
   nodeserv:
     tty: true
     build:
@@ -26,10 +28,12 @@ services:
     image: synerex_nodeserv
     volumes:
       - ./nodeserv:/go/src/github.com/synerex_nodeserv
+      - ./nodeserv/entrypoint.sh
     ports:
       - "9990:9990"
     networks: 
       - synerex_net
+      - default
 networks:
   synerex_net:
-    driver: bridge
+    external: true


### PR DESCRIPTION
#### 変更点
- `docker-compose.yml`のnetworksでexternalを有効にした。
- Readmeの更新  

#### 確認方法
- `docker-compose up`を実行する前に`docker network create synerex_net`を実行して、ネットワークを先に作成してください。